### PR TITLE
Fix eventsListener and  infoListener stacking

### DIFF
--- a/native/scripts/services/gep-service.js
+++ b/native/scripts/services/gep-service.js
@@ -5,6 +5,9 @@
  */
 const REGISTER_RETRY_TIMEOUT = 10000;
 
+let storedEventsListener = null;
+let storedInfoListener = null;
+
 export class GepService {
   static setRequiredFeatures(features, eventsListener, infoListener) {
     if (!features.length) this.setListeners(eventsListener, infoListener) // if there are no features, this is an sdk game. as such, just sign up directly
@@ -30,10 +33,18 @@ export class GepService {
   }
 
   static setListeners(eventsListener, infoListener) {
-    overwolf.games.events.onNewEvents.removeListener(eventsListener);
+    if (storedEventsListener) {
+      overwolf.games.events.onNewEvents.removeListener(storedEventsListener);
+      storedEventsListener = null;
+    }
     overwolf.games.events.onNewEvents.addListener(eventsListener);
+    storedEventsListener = eventsListener;
 
-    overwolf.games.events.onInfoUpdates2.removeListener(infoListener);
+    if (storedInfoListener) {
+      overwolf.games.events.onInfoUpdates2.removeListener(storedInfoListener);
+      storedInfoListener = null;
+    }
     overwolf.games.events.onInfoUpdates2.addListener(infoListener);
+    storedInfoListener = infoListener;
   }
 }


### PR DESCRIPTION
When the app is started when a game launches:
- the background window calls setListeners
- the in game window or second screen calls setListeners In the function the removeListener call is supposed to remove the events from background an replace them by the one from ingame. This does not work because the object sent to the function are not the same. This results as events being triggered twice everytime. For example the moving event in rainboww six pops twice on each move. The fix here store the object of the last added event to be able to remove it afterward.